### PR TITLE
Give test account ability to assume test role

### DIFF
--- a/config/prod/sceptre-integration-test-service-access.yaml
+++ b/config/prod/sceptre-integration-test-service-access.yaml
@@ -6,3 +6,16 @@ parameters:
     - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
     - arn:aws:iam::aws:policy/AmazonS3FullAccess
     - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+  PolicyDocument: >-
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "PublicRead",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": [ "sts:AssumeRole" ],
+          "Resource": [ "*" ]
+        }
+      ]
+    }


### PR DESCRIPTION
sceptre build failed with message..

```
An error occurred (AccessDenied) when calling the AssumeRole operation:
User: arn:aws:iam::XXXXXX:user/sceptre-integration-test-ServiceUser-179357JFOJ4GP
is not authorized to perform: sts:AssumeRole on resource:
arn:aws:iam::XXXXXXX:role/bootstrap-ci-service-access-ServiceRole-13M4IKJRFUISQ
```

This PR attempts to fix that error.