### PR TITLE
Enabling integration test user to assume a role

### DIFF
--- a/config/prod/sceptre-integration-test-service-access.yaml
+++ b/config/prod/sceptre-integration-test-service-access.yaml
@@ -27,7 +27,8 @@ parameters:
             "iam:UpdateRole",
             "iam:UpdateRoleDescription",
             "iam:CreateRole",
-            "iam:DeleteRole"
+            "iam:DeleteRole",
+            "sts:AssumeRole"
           ],
           "Resource": "*"
         }


### PR DESCRIPTION
Currently the Sceptre integration tests cannot actually test the `iam_role` feature in Sceptre because it cannot assume a role. This should fix that. 