### PR TITLE
Replace bootstrap user

### DIFF
--- a/config/prod/bootstrap-ci-service-access.yaml
+++ b/config/prod/bootstrap-ci-service-access.yaml
@@ -1,5 +1,0 @@
-template_path: service-account.yaml
-stack_name: bootstrap-ci-service-access
-parameters:
-  ManagedPolicyArns:
-    - arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
We are now using a sponsor's AWS account for testing Scepter.
The sponspor has already created a IAM user/role pair for managing
their AWS account.  We no longer need the account created from this
repo.