### PR TITLE
Setup GH OIDC for Sceptre tests

### DIFF
--- a/config/prod/gh-oidc-sceptre-tests.yaml
+++ b/config/prod/gh-oidc-sceptre-tests.yaml
@@ -1,0 +1,43 @@
+template:
+  path: github-oidc-provider.j2
+stack_name: gh-oidc-sceptre-tests
+parameters:
+  ProviderRoleName: gh-oidc-sceptre-tests
+  ProviderArn: !stack_output_external sagebase-github-oidc::ProviderArn
+  ManagedPolicyArns:
+    - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+    - arn:aws:iam::aws:policy/AmazonS3FullAccess
+    - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+    - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+  PolicyDocument: >-
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "iam:ListPolicy",
+            "iam:ListRoles",
+            "iam:AttachRolePolicy",
+            "iam:DeleteRolePolicy",
+            "iam:DetachRolePolicy",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListAttachedRolePolicies",
+            "iam:ListRolePolicies",
+            "iam:PutRolePolicy",
+            "iam:UpdateRole",
+            "iam:UpdateRoleDescription",
+            "iam:CreateRole",
+            "iam:DeleteRole",
+            "sts:AssumeRole"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+sceptre_user_data:
+  GitHubOrg: "Sceptre"
+  Repositories:
+    - name: "sceptre"
+      branches: [ "*" ]


### PR DESCRIPTION
Deploy a AWS OIDC provider to allow the Github `Sceptre/sceptre` repo CI instances acess to the AWS resources needed by the Sceptre integration tests.

This change partially resolves issue https://github.com/Sceptre/sceptre/issues/1401